### PR TITLE
Fix Node-RED backups when it's a link

### DIFF
--- a/lib/sync.sh
+++ b/lib/sync.sh
@@ -32,7 +32,7 @@ fi
 # Archive node-red
 if [ -d $NRdir -a $nodered = "Y" ];
 then
-cp -pr $NRdir $DIR/../$tdir
+cp -prL $NRdir $DIR/../$tdir
 fi
 
 # Prepare emoncms data archive and delete original


### PR DESCRIPTION
The Node-RED directory is a symlink on the emonpi:

```
$ ls -l ~pi/.node-red
lrwxrwxrwx 1 pi pi 23 Apr 29 00:33 /home/pi/.node-red -> /home/pi/data/node-red/
```

This means that we need a `-L` on the `cp` command when copying these files over, otherwise it'll just copy the link rather than the contents of the linked directory.
